### PR TITLE
Leaderboards

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -19,6 +19,8 @@ function App() {
     drawer: "",
     lastWinner: ""
   });
+  const [scores, setScores] = useState([]);
+
 
   useEffect(() => {
     socket.on("roomCreated", newRoomId => {
@@ -29,6 +31,9 @@ function App() {
     socket.on("roomJoined", ({ roomId, users }) => {
       setRoomId(roomId);
       setUsersInRoom(users);
+    });
+    socket.on("updateScores", updatedScores => {
+      setScores(updatedScores); // [["Andrei", 10], ["Maria", 5]]
     });
 
     socket.on("updateUsers", users => setUsersInRoom(users));
@@ -111,6 +116,7 @@ function App() {
       onStartGame={handleStartGame}
       onSendMessage={handleSendMessage}
       username={username}
+      scores={scores}
     />
   );
 }

--- a/client/src/components/GameRoom.jsx
+++ b/client/src/components/GameRoom.jsx
@@ -4,9 +4,10 @@ import Header from "./Header";
 import Chat from "./Chat";
 import DrawingBoard from "./DrawingBoard";
 import WinnerDisplay from "./WinnerDisplay";
+import Leaderboard from "./Leaderboard";
 
 export default function GameRoom(props) {
-  const { socket, roomId, isCreator, users, game, messages, onStartGame, onSendMessage, username } = props;
+  const { socket, roomId, isCreator, users, game, messages, onStartGame, onSendMessage, username, scores} = props;
   const isDrawer = game.drawer === username;
 
   return (
@@ -31,6 +32,7 @@ export default function GameRoom(props) {
         onSendMessage={onSendMessage}
         isDrawer={isDrawer}    // <-- nou
       />
+      <Leaderboard scores={scores} />
 
       {game.lastWinner && <WinnerDisplay winner={game.lastWinner} />}
     </div>

--- a/client/src/components/Leaderboard.jsx
+++ b/client/src/components/Leaderboard.jsx
@@ -1,0 +1,22 @@
+import React from "react";
+
+export default function Leaderboard({ scores }) {
+  const sorted = [...scores].sort((a, b) => b[1] - a[1]);
+
+  return (
+    <div style={styles.box}>
+      <h3>🏆 Clasament</h3>
+      <ul>
+        {sorted.map(([user, score], i) => (
+          <li key={user}>
+            {i + 1}. {user}: {score} puncte
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+const styles = {
+  box: { background: "#eee", padding: 10, borderRadius: 8, marginTop: 20 }
+};

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -343,6 +343,7 @@
       "version": "4.21.2",
       "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
       "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+      "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",


### PR DESCRIPTION
Implement dynamic scoring based on remaining drawing time

Guessers now earn more points the faster they guess the word.

Drawers earn more points the longer it takes for others to guess, rewarding more difficult drawings.

Scores are calculated proportionally based on the remaining time out of 60 seconds.

Also added proper state updates and score broadcasting to all clients.
